### PR TITLE
Make spec-compliant with JSON-RPC 2.0

### DIFF
--- a/lib/connection.js
+++ b/lib/connection.js
@@ -118,8 +118,8 @@ Connection.prototype.processPayload = function processPayload (payload) {
         if (id !== undefined && id !== null && typeof id !== 'string' && typeof id !== 'number') {
             return this.sendError('invalidRequest', id, { info: 'id, if provided, must be one of: null, string, number' });
         }
-        if (params !== null && typeof params !== 'object') {
-            return this.sendError('invalidRequest', id, { info: 'params must be one of: null, object, array' });
+        if (params !== undefined && params !== null && typeof params !== 'object') {
+            return this.sendError('invalidRequest', id, { info: 'params, if provided, must be one of: null, object, array' });
         }
         logger('message method %s', payload.method);
         if (id === null || id === undefined) {
@@ -155,7 +155,7 @@ Connection.prototype.processPayload = function processPayload (payload) {
  *
  * @param {String} id - id for the message
  * @param {Object} error - error for the message
- * @param {String} result - result for the message
+ * @param {String|Object|Array|Number} result - result for the message
  * @public
  *
  */
@@ -165,18 +165,22 @@ Connection.prototype.sendResult = function sendResult (id, error, result) {
     Assert(error || result, 'Must have an error or a result.');
     Assert( !( error && result ), 'Cannot have both an error and a result');
 
-    this.sendRaw({
-        id: id,
-        result: result,
-        error: error
-    });
+    var response = { id: id };
+
+    if (result) {
+        response.result = result;
+    } else {
+        response.error = error;
+    }
+
+    this.sendRaw(response);
 };
 
 /**
  * Send a method message
  *
  * @param {String} method - method for the message
- * @param {Array|null} params  - params for the message
+ * @param {Array|Object|null} params  - params for the message
  * @param {function} callback - optional callback for a reply from the message
  * @public
  */
@@ -184,18 +188,23 @@ Connection.prototype.sendMethod = function sendMethod (method, params, callback)
 
     var id = uuid();
     Assert((typeof method === 'string') && (method.length > 0), 'method must be a non-empty string');
-    Assert(params === null || params instanceof Array, 'params must be an array or null');
+    Assert(params === null || params === undefined || params instanceof Object, 'params, if provided,  must be an array, object or null');
     logger('sendMethod %s', method, id);
     if (callback) {
         this.responseHandlers[id] = callback;
     } else {
         this.responseHandlers[id] = emptyCallback;
     }
-    this.sendRaw({
+    var request = {
         id: id,
-        method: method,
-        params: params
-    });
+        method: method
+    };
+
+    if (params) {
+        request.params = params;
+    }
+
+    this.sendRaw(request);
 };
 
 /**

--- a/test/index.js
+++ b/test/index.js
@@ -66,15 +66,25 @@ lab.experiment('json-rpc ws', function () {
 
         client.send('reflect', ['test one'], function (error1, reply1) {
 
-            Code.expect(error1).to.be.null();
+            Code.expect(error1).to.equal(undefined);
             Code.expect(reply1).to.have.length(1);
             Code.expect(reply1[0]).to.equal('test one');
             client.send('reflect', ['test two'], function (error2, reply2) {
 
-                Code.expect(error2).to.equal(null);
+                Code.expect(error2).to.equal(undefined);
                 Code.expect(reply2).to.have.length(1);
                 Code.expect(reply2[0]).to.equal('test two');
-                done();
+                client.send('reflect', null, function (error3, reply3) {
+
+                    Code.expect(error3).to.equal(undefined);
+                    Code.expect(reply3).to.equal('empty');
+                    client.send('reflect', undefined, function (error3, reply3) {
+
+                        Code.expect(error3).to.equal(undefined);
+                        Code.expect(reply3).to.equal('empty');
+                        done();
+                    });
+                });
             });
         });
     });
@@ -83,7 +93,7 @@ lab.experiment('json-rpc ws', function () {
 
         client.send('error', null, function (error, reply) {
 
-            Code.expect(reply).to.be.null();
+            Code.expect(reply).to.equal(undefined);
             Code.expect(error).to.equal('error');
             done();
         });
@@ -137,7 +147,7 @@ lab.experiment('json-rpc ws', function () {
         });
         client.expose('info', function (params, reply) {
 
-            Code.expect(params).to.equal(null);
+            Code.expect(params).to.equal(undefined);
             reply(null, 'info ok');
         });
         client.send('saveConnection', null, function () {
@@ -279,7 +289,7 @@ lab.experiment('json-rpc ws', function () {
                     Code.expect(err).to.equal(null);
                     server.send(browserId, 'info', null, function (err, result) {
 
-                        Code.expect(err).to.equal(null);
+                        Code.expect(err).to.equal(undefined);
                         Code.expect(result).to.equal('browser');
                         driver.quit();
                         done();


### PR DESCRIPTION
http://www.jsonrpc.org/specification

Fixes the following deficits:

*Request*
- `params` member MAY be omitted
- `params` MUST BE an Array (by-position) OR an Object (by-name)

*Response*
- `result` member MUST NOT exist if there was an error invoking
  the method
- `error` member MUST NOT exist if there was no error triggered during
  invocation

I've also omitted request params if null, though this is optional.